### PR TITLE
Add zxcvbn to password validator

### DIFF
--- a/packages/frontend/app/routes/debuggery.js
+++ b/packages/frontend/app/routes/debuggery.js
@@ -21,6 +21,6 @@ export default class DebuggeryRoute extends Route {
   }
 
   async afterModel() {
-    await import('zxcvbn');
+    // await import('zxcvbn');
   }
 }

--- a/packages/frontend/app/routes/debuggery.js
+++ b/packages/frontend/app/routes/debuggery.js
@@ -21,6 +21,6 @@ export default class DebuggeryRoute extends Route {
   }
 
   async afterModel() {
-    // await import('zxcvbn');
+    await import('zxcvbn');
   }
 }

--- a/packages/frontend/tests/integration/components/password-validator-test.js
+++ b/packages/frontend/tests/integration/components/password-validator-test.js
@@ -37,4 +37,49 @@ module('Integration | Component | password-validator', function (hooks) {
     await component.fillIn('abcde');
     assert.false(component.hasError);
   });
+
+  test('password strength 0 display', async function (assert) {
+    await render(hbs`<PasswordValidator />`);
+
+    await component.fillIn('12345');
+    assert.strictEqual(component.meter.value, 0);
+    assert.strictEqual(component.strength.text, 'Try Harder');
+    assert.ok(component.strength.hasZeroClass);
+  });
+
+  test('password strength 1 display', async function (assert) {
+    await render(hbs`<PasswordValidator />`);
+
+    await component.fillIn('12345ab');
+    assert.strictEqual(component.meter.value, 1);
+    assert.strictEqual(component.strength.text, 'Bad');
+    assert.ok(component.strength.hasOneClass);
+  });
+
+  test('password strength 2 display', async function (assert) {
+    await render(hbs`<PasswordValidator />`);
+
+    await component.fillIn('12345ab13&');
+    assert.strictEqual(component.meter.value, 2);
+    assert.strictEqual(component.strength.text, 'Weak');
+    assert.ok(component.strength.hasTwoClass);
+  });
+
+  test('password strength 3 display', async function (assert) {
+    await render(hbs`<PasswordValidator />`);
+
+    await component.fillIn('12345ab13&!!');
+    assert.strictEqual(component.meter.value, 3);
+    assert.strictEqual(component.strength.text, 'Good');
+    assert.ok(component.strength.hasThreeClass);
+  });
+
+  test('password strength 4 display', async function (assert) {
+    await render(hbs`<PasswordValidator />`);
+
+    await component.fillIn('12345ab13&HHtB');
+    assert.strictEqual(component.meter.value, 4);
+    assert.strictEqual(component.strength.text, 'Strong');
+    assert.ok(component.strength.hasFourClass);
+  });
 });

--- a/packages/frontend/tests/integration/components/password-validator-test.js
+++ b/packages/frontend/tests/integration/components/password-validator-test.js
@@ -10,8 +10,6 @@ module('Integration | Component | password-validator', function (hooks) {
   test('it renders', async function (assert) {
     await render(hbs`<PasswordValidator />`);
 
-    console.log('component', component);
-
     assert.ok(component);
     assert.strictEqual(component.label, 'Password:');
   });
@@ -21,8 +19,6 @@ module('Integration | Component | password-validator', function (hooks) {
 
     assert.false(component.hasError);
     await component.submit();
-
-    console.log('component.hasError', component.hasError);
 
     assert.true(component.hasError);
   });

--- a/packages/frontend/tests/integration/components/password-validator-test.js
+++ b/packages/frontend/tests/integration/components/password-validator-test.js
@@ -1,0 +1,44 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { component } from 'frontend/tests/pages/components/password-validator';
+
+module('Integration | Component | password-validator', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`<PasswordValidator />`);
+
+    console.log('component', component);
+
+    assert.ok(component);
+    assert.strictEqual(component.label, 'Password:');
+  });
+
+  test('it fails blank password', async function (assert) {
+    await render(hbs`<PasswordValidator />`);
+
+    assert.false(component.hasError);
+    await component.submit();
+
+    console.log('component.hasError', component.hasError);
+
+    assert.true(component.hasError);
+  });
+
+  test('it fails short password', async function (assert) {
+    await render(hbs`<PasswordValidator />`);
+
+    await component.fillIn('abc');
+    await component.submit();
+    assert.true(component.hasError);
+  });
+
+  test('it passes valid password', async function (assert) {
+    await render(hbs`<PasswordValidator />`);
+
+    await component.fillIn('abcde');
+    assert.false(component.hasError);
+  });
+});

--- a/packages/frontend/tests/pages/components/password-validator.js
+++ b/packages/frontend/tests/pages/components/password-validator.js
@@ -1,0 +1,34 @@
+import {
+  clickable,
+  create,
+  fillable,
+  hasClass,
+  isVisible,
+  text,
+  triggerable,
+  value,
+} from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-password-validator]',
+  label: text('label'),
+  fillIn: fillable('input'),
+  value: value('input'),
+  validate: clickable('button'),
+  hasError: isVisible('.validation-error-message'),
+  submit: triggerable('keyup', 'input', { eventProperties: { key: 'Enter' } }),
+  strength: {
+    scope: '[data-test-password-strength-text]',
+    hasZeroClass: hasClass('strength-0'),
+    hasOneClass: hasClass('strength-1'),
+    hasTwoClass: hasClass('strength-2'),
+    hasThreeClass: hasClass('strength-3'),
+    hasFourClass: hasClass('strength-4'),
+  },
+  meter: {
+    scope: '[data-test-password-strength-meter]',
+  },
+};
+
+export default definition;
+export const component = create(definition);

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -34,6 +34,7 @@ general:
   addNew: Add New
   author: Author
   back: Back
+  bad: Bad
   by: by
   cancel: Cancel
   chooseFile: Choose File
@@ -76,6 +77,7 @@ general:
   from: from
   fullName: Full Name
   go: Go
+  good: Good
   greeting: "Hello, I'm {name}"
   gt: ">"
   helloWorld: Hello World!
@@ -135,6 +137,7 @@ general:
   starts: Starts
   startTime: Start Time
   status: Status
+  strong: Strong
   summary: Summary
   sunday: Sunday
   teachingTomster: Teaching Tomster
@@ -155,6 +158,7 @@ general:
   users: Users
   userRole: User Role
   view: View
+  weak: Weak
   wednesday: Wednesday
   week: Week
   weekOf: "Week of {date}"

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -49,6 +49,7 @@ general:
   addNew: Agregue Nuevo
   author: Autor
   back: Volver
+  bad: Malo
   by: de
   cancel: Cancelar
   chooseFile: Seleccione Archivo
@@ -91,6 +92,7 @@ general:
   from: de
   fullName: Nombre Completo
   go: Vaya
+  good: Bueno
   greeting: "Hola, me llamo {name}"
   gt: ">"
   helloWorld: ¡Hola Mundo!
@@ -150,6 +152,7 @@ general:
   starts: Empieza
   startTime: Hora de Iniciar
   status: Estado
+  strong: Fuerte
   summary: Resumen
   sunday: Domingo
   teachingTomster: Tomster de Enseñanza
@@ -170,6 +173,7 @@ general:
   users: Usuarios
   userRole: Función de Usuario
   view: Vista
+  weak: Débil
   wednesday: Miercoles
   week: Semana
   weekOf: "Semana de {date}"

--- a/packages/rs-common/addon/components/password-validator.hbs
+++ b/packages/rs-common/addon/components/password-validator.hbs
@@ -1,6 +1,6 @@
 <h3>{{t "components.passwordValidator.head"}}</h3>
 {{#let (unique-id) as |templateId|}}
-  <div class="password-validator" data-test-password-validator ...attributes>
+  <div class="password-validator" data-test-password-validator>
     <label for="password-{{templateId}}">
       {{t "general.password"}}:
     </label>
@@ -8,10 +8,31 @@
       id="password-{{templateId}}"
       type="text"
       value={{this.password}}
-      {{on "input" (pick "target.value" (set this "password"))}}
+      {{on "input" (pick "target.value" this.setPassword)}}
       {{on "keyup" (queue (fn this.addErrorDisplayFor "password") (perform this.saveOrCancel))}}
+      data-test-password-input
     />
-    <ValidationError @errors={{get-errors-for this.password}} />
+    {{#if (has-error-for this.password)}}
+      <ValidationError @errors={{get-errors-for this.password}} />
+    {{else if (gt this.password.length 0)}}
+      <span
+        class="password-strength {{concat 'strength-' this.passwordStrengthScore}}"
+        data-test-password-strength-text
+      >
+        {{#if (eq this.passwordStrengthScore 0)}}
+          {{t "general.tryHarder"}}
+        {{else if (eq this.passwordStrengthScore 1)}}
+          {{t "general.bad"}}
+        {{else if (eq this.passwordStrengthScore 2)}}
+          {{t "general.weak"}}
+        {{else if (eq this.passwordStrengthScore 3)}}
+          {{t "general.good"}}
+        {{else if (eq this.passwordStrengthScore 4)}}
+          {{t "general.strong"}}
+        {{/if}}
+      </span>
+      <meter max="4" value={{this.passwordStrengthScore}} data-test-password-strength-meter></meter>
+    {{/if}}
     <div class="buttons">
       <button
         type="button"

--- a/packages/rs-common/addon/components/password-validator.js
+++ b/packages/rs-common/addon/components/password-validator.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-// import { isEmpty } from '@ember/utils';
+import { isEmpty } from '@ember/utils';
 import { dropTask, timeout } from 'ember-concurrency';
 import { validatable, Length, NotBlank } from 'rs-common/decorators/validation';
 
@@ -21,10 +21,10 @@ export default class PasswordValidatorComponent extends Component {
   }
 
   async calculatePasswordStrengthScore() {
-    // const { default: zxcvbn } = await import('zxcvbn');
-    // const password = isEmpty(this.password) ? '' : this.password;
-    // const obj = zxcvbn(password);
-    // this.passwordStrengthScore = obj.score;
+    const { default: zxcvbn } = await import('zxcvbn');
+    const password = isEmpty(this.password) ? '' : this.password;
+    const obj = zxcvbn(password);
+    this.passwordStrengthScore = obj.score;
   }
 
   save = dropTask(async () => {

--- a/packages/rs-common/addon/components/password-validator.js
+++ b/packages/rs-common/addon/components/password-validator.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { isEmpty } from '@ember/utils';
+// import { isEmpty } from '@ember/utils';
 import { dropTask, timeout } from 'ember-concurrency';
 import { validatable, Length, NotBlank } from 'rs-common/decorators/validation';
 
@@ -21,10 +21,10 @@ export default class PasswordValidatorComponent extends Component {
   }
 
   async calculatePasswordStrengthScore() {
-    const { default: zxcvbn } = await import('zxcvbn');
-    const password = isEmpty(this.password) ? '' : this.password;
-    const obj = zxcvbn(password);
-    this.passwordStrengthScore = obj.score;
+    // const { default: zxcvbn } = await import('zxcvbn');
+    // const password = isEmpty(this.password) ? '' : this.password;
+    // const obj = zxcvbn(password);
+    // this.passwordStrengthScore = obj.score;
   }
 
   save = dropTask(async () => {

--- a/packages/rs-common/addon/components/password-validator.js
+++ b/packages/rs-common/addon/components/password-validator.js
@@ -1,6 +1,8 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
+// import { isEmpty } from '@ember/utils';
 import { dropTask, timeout } from 'ember-concurrency';
 import { validatable, Length, NotBlank } from 'rs-common/decorators/validation';
 
@@ -10,6 +12,20 @@ export default class PasswordValidatorComponent extends Component {
 
   @tracked @Length(5) @NotBlank() password = null;
   @tracked isSaving = false;
+  @tracked passwordStrengthScore = 0;
+
+  @action
+  async setPassword(password) {
+    this.password = password;
+    await this.calculatePasswordStrengthScore();
+  }
+
+  async calculatePasswordStrengthScore() {
+    // const { default: zxcvbn } = await import('zxcvbn');
+    // const password = isEmpty(this.password) ? '' : this.password;
+    // const obj = zxcvbn(password);
+    // this.passwordStrengthScore = obj.score;
+  }
 
   save = dropTask(async () => {
     this.addErrorDisplaysFor(['password']);
@@ -27,7 +43,6 @@ export default class PasswordValidatorComponent extends Component {
     const enterKey = 13;
 
     if (enterKey === keyCode) {
-      console.log('PasswordValidator enter key pressed');
       await this.save.perform();
     }
   });

--- a/packages/rs-common/package.json
+++ b/packages/rs-common/package.json
@@ -52,7 +52,8 @@
     "query-string": ">= 9.1.0",
     "scroll-into-view": ">= 1.16.0",
     "striptags": ">= 3.2.0",
-    "validator": ">= 13.12.0"
+    "validator": ">= 13.12.0",
+    "zxcvbn": "^4.4.2"
   },
   "peerDependencies": {
     "@ember-data/adapter": "5.3.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,6 +413,9 @@ importers:
       validator:
         specifier: '>= 13.12.0'
         version: 13.12.0
+      zxcvbn:
+        specifier: ^4.4.2
+        version: 4.4.2
     devDependencies:
       '@babel/eslint-parser':
         specifier: ^7.24.7
@@ -8781,10 +8784,10 @@ snapshots:
 
   '@glimmer/compiler@0.92.0':
     dependencies:
-      '@glimmer/interfaces': 0.92.0
-      '@glimmer/syntax': 0.92.0
-      '@glimmer/util': 0.92.0
-      '@glimmer/vm': 0.92.0
+      '@glimmer/interfaces': 0.92.3
+      '@glimmer/syntax': 0.92.3
+      '@glimmer/util': 0.92.3
+      '@glimmer/vm': 0.92.3
       '@glimmer/wire-format': 0.92.3
 
   '@glimmer/component@1.1.2(@babel/core@7.25.8)':
@@ -8817,8 +8820,8 @@ snapshots:
     dependencies:
       '@glimmer/env': 0.1.7
       '@glimmer/global-context': 0.92.0
-      '@glimmer/interfaces': 0.92.0
-      '@glimmer/util': 0.92.0
+      '@glimmer/interfaces': 0.92.3
+      '@glimmer/util': 0.92.3
 
   '@glimmer/di@0.1.11': {}
 
@@ -8853,17 +8856,17 @@ snapshots:
       '@glimmer/destroyable': 0.92.0
       '@glimmer/env': 0.1.7
       '@glimmer/global-context': 0.92.0
-      '@glimmer/interfaces': 0.92.0
+      '@glimmer/interfaces': 0.92.3
       '@glimmer/reference': 0.92.0
-      '@glimmer/util': 0.92.0
+      '@glimmer/util': 0.92.3
       '@glimmer/validator': 0.92.0
-      '@glimmer/vm': 0.92.0
+      '@glimmer/vm': 0.92.3
 
   '@glimmer/node@0.92.0':
     dependencies:
-      '@glimmer/interfaces': 0.92.0
+      '@glimmer/interfaces': 0.92.3
       '@glimmer/runtime': 0.92.0
-      '@glimmer/util': 0.92.0
+      '@glimmer/util': 0.92.3
       '@simple-dom/document': 1.4.0
 
   '@glimmer/opcode-compiler@0.92.0':
@@ -8872,26 +8875,26 @@ snapshots:
       '@glimmer/encoder': 0.92.3
       '@glimmer/env': 0.1.7
       '@glimmer/global-context': 0.92.0
-      '@glimmer/interfaces': 0.92.0
+      '@glimmer/interfaces': 0.92.3
       '@glimmer/manager': 0.92.0
       '@glimmer/reference': 0.92.0
-      '@glimmer/util': 0.92.0
-      '@glimmer/vm': 0.92.0
+      '@glimmer/util': 0.92.3
+      '@glimmer/vm': 0.92.3
       '@glimmer/wire-format': 0.92.3
 
   '@glimmer/owner@0.92.0':
     dependencies:
-      '@glimmer/util': 0.92.0
+      '@glimmer/util': 0.92.3
 
   '@glimmer/program@0.92.0':
     dependencies:
       '@glimmer/encoder': 0.92.3
       '@glimmer/env': 0.1.7
-      '@glimmer/interfaces': 0.92.0
+      '@glimmer/interfaces': 0.92.3
       '@glimmer/manager': 0.92.0
       '@glimmer/opcode-compiler': 0.92.0
-      '@glimmer/util': 0.92.0
-      '@glimmer/vm': 0.92.0
+      '@glimmer/util': 0.92.3
+      '@glimmer/vm': 0.92.3
       '@glimmer/wire-format': 0.92.3
 
   '@glimmer/reference@0.84.3':
@@ -8906,8 +8909,8 @@ snapshots:
     dependencies:
       '@glimmer/env': 0.1.7
       '@glimmer/global-context': 0.92.0
-      '@glimmer/interfaces': 0.92.0
-      '@glimmer/util': 0.92.0
+      '@glimmer/interfaces': 0.92.3
+      '@glimmer/util': 0.92.3
       '@glimmer/validator': 0.92.0
 
   '@glimmer/runtime@0.92.0':
@@ -8915,14 +8918,14 @@ snapshots:
       '@glimmer/destroyable': 0.92.0
       '@glimmer/env': 0.1.7
       '@glimmer/global-context': 0.92.0
-      '@glimmer/interfaces': 0.92.0
+      '@glimmer/interfaces': 0.92.3
       '@glimmer/manager': 0.92.0
       '@glimmer/owner': 0.92.0
       '@glimmer/program': 0.92.0
       '@glimmer/reference': 0.92.0
-      '@glimmer/util': 0.92.0
+      '@glimmer/util': 0.92.3
       '@glimmer/validator': 0.92.0
-      '@glimmer/vm': 0.92.0
+      '@glimmer/vm': 0.92.3
       '@glimmer/wire-format': 0.92.3
 
   '@glimmer/syntax@0.84.3':
@@ -8934,8 +8937,8 @@ snapshots:
 
   '@glimmer/syntax@0.92.0':
     dependencies:
-      '@glimmer/interfaces': 0.92.0
-      '@glimmer/util': 0.92.0
+      '@glimmer/interfaces': 0.92.3
+      '@glimmer/util': 0.92.3
       '@glimmer/wire-format': 0.92.3
       '@handlebars/parser': 2.0.0
       simple-html-tokenizer: 0.5.11
@@ -8964,7 +8967,7 @@ snapshots:
   '@glimmer/util@0.92.0':
     dependencies:
       '@glimmer/env': 0.1.7
-      '@glimmer/interfaces': 0.92.0
+      '@glimmer/interfaces': 0.92.3
 
   '@glimmer/util@0.92.3':
     dependencies:
@@ -8982,8 +8985,8 @@ snapshots:
     dependencies:
       '@glimmer/env': 0.1.7
       '@glimmer/global-context': 0.92.0
-      '@glimmer/interfaces': 0.92.0
-      '@glimmer/util': 0.92.0
+      '@glimmer/interfaces': 0.92.3
+      '@glimmer/util': 0.92.3
 
   '@glimmer/vm-babel-plugins@0.92.0(@babel/core@7.25.8)':
     dependencies:
@@ -8993,8 +8996,8 @@ snapshots:
 
   '@glimmer/vm@0.92.0':
     dependencies:
-      '@glimmer/interfaces': 0.92.0
-      '@glimmer/util': 0.92.0
+      '@glimmer/interfaces': 0.92.3
+      '@glimmer/util': 0.92.3
 
   '@glimmer/vm@0.92.3':
     dependencies:


### PR DESCRIPTION
Due to it currently not working, the [route](https://github.com/michaelchadwick/ember-remember-stuff/blob/main/packages/frontend/app/routes/debuggery.js) and [component](https://github.com/michaelchadwick/ember-remember-stuff/blob/main/packages/rs-common/addon/components/password-validator.js) mentions of `zxcvbn` are commented out. To test this PR, uncomment them.