### PR TITLE
Add aardvark component and display ant count

### DIFF
--- a/packages/frontend/app/components/aardvark.gjs
+++ b/packages/frontend/app/components/aardvark.gjs
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+
+export default class extends Component {
+  ants = 10;
+
+  get antCount() {
+    return this.ants;
+  }
+  <template>
+    <span class="ant-count">{{this.antCount}}</span>
+  </template>
+}

--- a/packages/frontend/app/components/layout/footer.gjs
+++ b/packages/frontend/app/components/layout/footer.gjs
@@ -5,6 +5,7 @@ import t from 'ember-intl/helpers/t';
 import { LinkTo } from '@ember/routing';
 import AudioPlayer from 'frontend/components/audio-player';
 import FaIcon from 'frontend/components/fa-icon';
+import Aardvark from 'frontend/components/aardvark';
 
 export default class FooterComponent extends Component {
   @service intl;
@@ -88,6 +89,8 @@ export default class FooterComponent extends Component {
         {{@rsVersionTag}}
         {{@apiVersionTag}}
         {{@frontendVersionTag}}
+        [{{t "general.antCount"}}:
+        <Aardvark />]
       </div>
     </footer>
   </template>

--- a/packages/frontend/tests/integration/components/aardvark-test.gjs
+++ b/packages/frontend/tests/integration/components/aardvark-test.gjs
@@ -1,0 +1,15 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend/tests/helpers';
+import { render } from '@ember/test-helpers';
+import Aardvark from 'frontend/components/aardvark';
+
+module('Integration | Component | aardvark', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(<template><Aardvark /></template>);
+
+    assert.dom('.ant-count').exists();
+    assert.dom('.ant-count').hasText('10');
+  });
+});

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -80,6 +80,7 @@ general:
   add: Add
   addNew: Add New
   anonymousUser: Anonymous User
+  antCount: Ants
   author: Author
   back: Back
   bad: Bad

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -80,6 +80,7 @@ general:
   add: Agregue
   addNew: Agregue Nuevo
   anonymousUser: Usuario anónim(a/o)
+  antCount: Hormigas
   author: Autor
   back: Volver
   bad: Malo


### PR DESCRIPTION
This adds an `Aardvark` component that has an `ants` property and displays it in the footer. This was created to show that a class can have no name (e.g. `export default class extends Component`) and still work.